### PR TITLE
avoid zooming when the clicked rem has a lot of child rems  @sotiwin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npx remnote-plugin validate && shx rm -rf dist && cross-env NODE_ENV=production webpack --color --progress && shx cp README.md dist && cd dist && bestzip ../PluginZip.zip ./*"
   },
   "dependencies": {
-    "@remnote/plugin-sdk": "^0.0.35",
+    "@remnote/plugin-sdk": "^0.0.40",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/src/widgets/table_of_contents.tsx
+++ b/src/widgets/table_of_contents.tsx
@@ -40,7 +40,8 @@ export const TableOfContentsWidget = () => {
     await expandHighestCollapsedAncestor(remId, plugin);
     // jump to the rem
     let rem = await plugin.rem.findOne(remId);
-    await rem?.openRemInContext();
+    let parentRemId = await plugin.window.getOpenPaneRemId(await plugin.window.getFocusedPaneId())
+    await rem?.openRemInContext(parentRemId);
   };
 
   return (


### PR DESCRIPTION
### Summary 🎯

When a header element has a lot of children clicking the header at table of contents "zooms in" one level and opens the selected rem instead of just scrolling.

### Changes 🔁
There is a new parameter in Rem.openRemInContext: portalId. When you set it to the id of currently opened Rem, it prevents zooming.  

