### PR TITLE
Change the indent to be based on the header size, rather than on whether it is underneath its parent element.

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,11 +28,11 @@ async function buildChildren(
   const children = await Promise.all(
     childrenRem.map(async (child) => {
       const isHeader = await isHeaderRem(child);
+      const headerType = await child.getFontSize();
       if (!isHeader) {
         return {};
       }
-
-      return buildContent(depth, child, plugin);
+      return buildContent(Number(headerType?headerType[1]:1), child, plugin);
     })
   );
 


### PR DESCRIPTION
I didn’t indent the child elements within their parent element in the document, causing all the headers to be indented at the same level, regardless of whether they are H1, H2, or H3.

It's really hard for me to distinguish the Header level.

![image](https://github.com/user-attachments/assets/01c73b45-8596-490f-a440-deb901ca74d3)

So I changed the code to make the indent solely based on the header size. Now it looks like this:

![image](https://github.com/user-attachments/assets/29030453-6ff6-49d9-90ec-6036556947f0)
